### PR TITLE
[wip] `npm run build` on master on older node

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**/node_modules/
+# .git
+
+# dist
+# example

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
 **/node_modules/
-# .git
-
-# dist
-# example
+.git/
+dist/

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 example/public/
 node_modules/
+dist/

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
 example/public/
 node_modules/
-dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+ARG NODE_VERSION=16
+
+FROM node:${NODE_VERSION} as builder
+USER node
+WORKDIR /home/node/app
+
+# copy package.json and package-lock.json
+COPY package*.json ./
+RUN npm install
+
+# copy files required for npm run build
+COPY .babelrc webpack.config.js README.md LICENSE ./
+COPY src ./src
+COPY types ./types
+
+RUN npm run build
+
+# pack will generate tarball with filename $name-$version.tgz
+RUN  mkdir ../build \
+    && npm pack --json --pack-destination ../build ./dist > ../build/pack-log.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-ARG NODE_VERSION=16
+ARG NODE_VERSION=14
 
 FROM node:${NODE_VERSION} as builder
+
+RUN apt update && apt install -y vim
+
 USER node
 WORKDIR /home/node/app
 
@@ -8,13 +11,12 @@ WORKDIR /home/node/app
 COPY package*.json ./
 RUN npm install
 
-# copy files required for npm run build
-COPY .babelrc webpack.config.js README.md LICENSE ./
-COPY src ./src
-COPY types ./types
+COPY --chown=node . ./
 
-RUN npm run build
+RUN npm run clean \
+    && npm run build
 
 # pack will generate tarball with filename $name-$version.tgz
 RUN  mkdir ../build \
-    && npm pack --json --pack-destination ../build ./dist > ../build/pack-log.json
+    && npm pack --json ./dist > ../build/pack-log.json \
+    && mv react-firebaseui-6.0.0.tgz ../build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ ARG NODE_VERSION=14
 
 FROM node:${NODE_VERSION} as builder
 
-RUN apt update && apt install -y vim
-
 USER node
 WORKDIR /home/node/app
 
@@ -12,6 +10,8 @@ COPY package*.json ./
 RUN npm install
 
 COPY --chown=node . ./
+
+RUN npm run lint
 
 RUN npm run clean \
     && npm run build

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "main": "index.js",
   "scripts": {
+    "lint": "eslint . --ext .js,.jsx",
     "clean": "rm -rf ./dist",
     "build": "webpack -p && babel src --out-dir dist -s && cp ./types/* README.md LICENSE package.json dist && cd dist && npm install --only=production && cd -",
     "pub": "npm run clean && npm run build && npm publish dist"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "main": "index.js",
   "scripts": {
-    "lint": "eslint . --ext .js,.jsx",
+    "lint": "eslint . --ext .js,.jsx --ignore-pattern dist/",
     "clean": "rm -rf ./dist",
     "build": "webpack -p && babel src --out-dir dist -s && cp ./types/* README.md LICENSE package.json dist && cd dist && npm install --only=production && cd -",
     "pub": "npm run clean && npm run build && npm publish dist"

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+docker build -t firebaseui-web-react:build .
+docker create --name extract firebaseui-web-react:build
+
+# pull the built artifact
+docker cp extract:/home/node/build/react-firebaseui-6.0.0.tgz .
+
+# cleanup
+docker rm -f extract


### PR DESCRIPTION
[upstream](https://github.com/firebase/firebaseui-web-react)'s master branch is quite old. with newer node (tested with >=18) `npm run build` does not run cleanly.

This PR adds a dockerfile to do that on older versions.